### PR TITLE
Anyone can add/modify/delete links (even if it isn't logged in)

### DIFF
--- a/app/controllers/menutabs_controller.rb
+++ b/app/controllers/menutabs_controller.rb
@@ -1,6 +1,7 @@
 class MenutabsController < ApplicationController
     unloadable
 
+    before_filter :require_login
     before_filter :find_menutab, :only => [:edit]
     def index
       list


### PR DESCRIPTION
Until now, anyone can add/modify/delete links (even if it isn't logged in). Adding the filter require_login solves that part. But one should go even further as besides being logged in, special permissions should be in place: only admin can add/modify/delete links or a new set of permissions should be created for that purpose (add/modify/delete).
